### PR TITLE
BE-BUG-02: Restrict default admin to non-production profiles

### DIFF
--- a/backend/src/main/java/com/soma/backend/config/DataInitializer.java
+++ b/backend/src/main/java/com/soma/backend/config/DataInitializer.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-@Profile("!test")
+@Profile({"local", "dev"})
 public class DataInitializer implements CommandLineRunner {
 
     @Value("${app.admin.email}")
@@ -45,6 +45,11 @@ public class DataInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         log.info("Running DataInitializer with adminEmail={} and adminPassword set? {}", adminEmail, adminPassword != null);
+
+        if (adminEmail == null || adminEmail.isBlank() || adminPassword == null || adminPassword.isBlank()) {
+            throw new IllegalStateException("APP_ADMIN_EMAIL または APP_ADMIN_PASSWORD が設定されていません。環境変数または application-*.properties に設定してください。");
+        }
+
         // Initialize roles
         if (roleRepository.findByName(ERole.ROLE_ADMIN).isEmpty()) {
             roleRepository.save(new Role(ERole.ROLE_ADMIN));

--- a/backend/src/main/java/com/soma/backend/config/DataLoader.java
+++ b/backend/src/main/java/com/soma/backend/config/DataLoader.java
@@ -1,6 +1,7 @@
 package com.soma.backend.config;
 
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -8,6 +9,7 @@ import com.soma.backend.entity.User;
 import com.soma.backend.repository.UserRepository;
 
 @Component
+@Profile({"local", "dev", "test"})
 public class DataLoader implements CommandLineRunner {
 
     private final UserRepository userRepository;


### PR DESCRIPTION
## Overview\nデフォルト管理者 (admin@example.com / password) が本番・プレビュー環境でも作成されてしまう問題を修正します。\n\n### 主な変更点\n1. **DataInitializer**\n   -  に変更し、本番/preview では実行しない。\n   - 環境変数   が未設定時に起動失敗させるガードを追加。\n2. **DataLoader**\n   - テストプロファイルからの動作を維持するため  に変更。\n\n### テスト\n-  で既存テストがグリーンになることを確認。\n- 本番プロフィールでは DataInitializer/DataLoader が走らないことを手動検証済み。\n\n### 影響範囲\n- バックエンド起動時の初期データ投入処理のみ。\n- 既存 API 仕様・フロントエンドには影響なし。\n\nよろしくお願いします。