### PR TITLE
fix(auth): revert SameSite to Strict - restore working configuration

### DIFF
--- a/backend/src/main/java/com/soma/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/soma/backend/controller/AuthController.java
@@ -45,7 +45,7 @@ public class AuthController {
                     .path("/")
                     .maxAge(24 * 60 * 60) // 1 day
                     .secure("prod".equals(activeProfile)) // Set Secure flag only in production
-                    .sameSite("prod".equals(activeProfile) ? "None" : "Lax")
+                    .sameSite("Strict")
                     .build();
 
             return ResponseEntity.ok()


### PR DESCRIPTION
SameSite=None設定により本番環境で認証が正常に動作しない問題を修正。以前正常に動作していたSameSite=Strict設定に戻す。