### PR TITLE
fix(security): ensure roles are loaded to prevent 403 on admin endpoints (BE-11)

### DIFF
--- a/backend/src/main/java/com/soma/backend/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/soma/backend/security/CustomUserDetailsService.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.soma.backend.entity.User;
 import com.soma.backend.repository.UserRepository;
@@ -21,6 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + username));


### PR DESCRIPTION
### 変更点\n*  に  を追加し、Hibernate の LazyInitializationException を防止\n\n### 背景\n* POST /api/contents/articles が 403 を返し、ログに LazyInitializationException が出力されていた\n* これは  が LAZY ロードのままセッションが閉じて取得できなかったことが原因\n\n### 確認手順\n1. ログイン\n2. クッキーを付与して POST /api/contents/articles を実行\n3. 201 Created が返ることを確認\n\nCloses #BE-11