### PR TITLE
Fix(CI): ワークフローにパッケージ書き込み権限を付与

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   frontend-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read # デプロイは読み取りだけで良い
+
 jobs:
   deploy:
     name: Deploy to GCP Compute Engine


### PR DESCRIPTION
## 概要
デプロイ実行時に発生した  エラーを修正します。

## 変更点
-  と  に  ブロックを追加し、 および  権限を明示的に付与しました。

## 影響
これにより、GitHub ActionsのワークフローがGHCR（GitHub Container Registry）に対してイメージをプッシュする権限を持つようになります。