### PR TITLE
Fix(CI): Add :latest tag to GHCR images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/frontend
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push frontend image
         uses: docker/build-push-action@v6
@@ -149,6 +154,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/backend
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push backend image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## 概要
デプロイ実行時に発生した  エラーを修正します。

## 変更点
-  の  に設定を追加し、ブランチへのプッシュ時に自動で  タグが付与されるようにしました。

## 影響
これにより、デプロイ先のVMが常に  タグのイメージを正常にpullできるようになります。