### PR TITLE
CD-03: Vercel自動デプロイWorkflowの復活

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,0 +1,32 @@
+name: Deploy Frontend to Vercel
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  deploy-vercel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Vercel (Preview)
+        uses: amondnet/vercel-action@v20
+        if: github.ref != 'refs/heads/main'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          zeit-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel (Production)
+        uses: amondnet/vercel-action@v20
+        if: github.ref == 'refs/heads/main'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          zeit-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod' 


### PR DESCRIPTION
## 目的\nGCPへのCD実装時に削除されていたVercel自動デプロイを復活させます。\n\n## 変更点\n- .github/workflows/deploy-vercel.yml 追加\n- amondnet/vercel-action@v20 を使用\n- VERCEL_* シークレットで認証\n- push main → Production, PR/その他 → Preview デプロイを実行\n\n## 動作確認\nGitHub Actions で Workflow が正常に完走し、Vercel のダッシュボードに preview/production デプロイが作成されることを確認予定。\n\n## レビュー観点\n- シークレット名が正しいか\n- ワークフローのトリガー条件に問題がないか\n