### PR TITLE
CD-04: Vercel GitHubアプリ連携への切替

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,0 +1,32 @@
+name: Deploy Frontend to Vercel
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  deploy-vercel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Vercel (Preview)
+        uses: amondnet/vercel-action@v20
+        if: github.ref != 'refs/heads/main'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          zeit-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel (Production)
+        uses: amondnet/vercel-action@v20
+        if: github.ref == 'refs/heads/main'
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          zeit-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod' 

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,10 +1,7 @@
 name: Deploy Frontend to Vercel
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
   deploy-vercel:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,8 @@ services:
   backend:
     image: somapages/backend:latest # Replace with your actual production image
     restart: always
+    ports:
+      - "8080:8080"
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}


### PR DESCRIPTION
## 目的\nGitHub Actionsベースの Vercel デプロイを停止し、公式 GitHub App 連携に戻す。\n\n## 変更点\n-  を自動トリガーから  のみへ変更（実質無効化）。\n\n## 次の作業\n1. リポジトリ設定 > Apps で **Vercel** アプリをインストール（Organization 全体 or リポジトリ単位）\n2. Vercel ダッシュボードで対象プロジェクトを本リポジトリにリンク\n   - GitHub App 連携が有効になると push/PR に応じて自動で Preview/Production デプロイが走る\n3. Vercel 側で  (デフォルト) のままにする\n4. 不要になった  Secrets は削除してOK\n\nご確認ください。